### PR TITLE
Fix nginx upstream for K3s service name

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,7 +6,7 @@ server {
 
     # API proxy to backend
     location /api/ {
-        proxy_pass http://backend:3000/api/;
+        proxy_pass http://guardquote-backend:3000/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Restore `guardquote-backend` as the nginx upstream name (K3s service name)
- Previous commit changed it to `backend` for docker-compose testing, which broke K3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)