### PR TITLE
feat(quote): cybersecurity / online consulting quote type

### DIFF
--- a/frontend/src/layouts/PublicLayout.tsx
+++ b/frontend/src/layouts/PublicLayout.tsx
@@ -65,6 +65,7 @@ export default function PublicLayout() {
                 <li><Link to="/quote/individual" className="hover:text-accent">Personal Security</Link></li>
                 <li><Link to="/quote/business" className="hover:text-accent">Business Security</Link></li>
                 <li><Link to="/quote/security" className="hover:text-accent">Event Security</Link></li>
+                <li><Link to="/quote/cyber" className="hover:text-accent">Cybersecurity / Online</Link></li>
               </ul>
             </div>
             <div>

--- a/frontend/src/pages/QuoteForm.tsx
+++ b/frontend/src/pages/QuoteForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import { Shield, MapPin, Calendar, Users, Clock, DollarSign, Loader2, CheckCircle2, Building2, User, PartyPopper, ChevronRight, Phone, Mail } from "lucide-react";
+import { Shield, MapPin, Calendar, Users, Clock, DollarSign, Loader2, CheckCircle2, Building2, User, PartyPopper, ChevronRight, Phone, Mail, Cloud, Lock } from "lucide-react";
 
 interface EventType { id: number; name: string; code: string; }
 interface Location { id: number; city: string; state: string; risk_score: number; }
@@ -25,6 +25,13 @@ export default function QuoteForm() {
     name: "",
     email: "",
     phone: "",
+    // Cybersecurity fields
+    cyberService: "", // compliance | performance | advisement
+    framework: "",    // SOC2 | HIPAA | PCI | ISO27001 | NIST | other | none
+    deployment: "",   // cloud | on_prem | hybrid | unsure
+    headcount: 25,
+    infraScale: "",   // small | medium | large
+    urgency: "",      // standard | priority | urgent
   });
   
   useEffect(() => {
@@ -45,10 +52,50 @@ export default function QuoteForm() {
     }
   }, [type]);
   
+  const isCyber = form.quoteType === "cyber";
+
+  const computeCyberPrice = () => {
+    const serviceBase: Record<string, number> = {
+      compliance: 6500,
+      performance: 4200,
+      advisement: 5000,
+    };
+    const scaleMult: Record<string, number> = { small: 1.0, medium: 1.6, large: 2.4 };
+    const urgencyMult: Record<string, number> = { standard: 1.0, priority: 1.25, urgent: 1.6 };
+    const deploymentMult: Record<string, number> = { cloud: 1.0, on_prem: 1.1, hybrid: 1.2, unsure: 1.05 };
+    const frameworkMult: Record<string, number> = {
+      SOC2: 1.2, HIPAA: 1.3, PCI: 1.35, ISO27001: 1.4, NIST: 1.25, other: 1.15, none: 1.0,
+    };
+
+    const base = serviceBase[form.cyberService] ?? 5000;
+    const scale = scaleMult[form.infraScale] ?? 1.0;
+    const urg = urgencyMult[form.urgency] ?? 1.0;
+    const dep = form.cyberService !== "compliance" ? (deploymentMult[form.deployment] ?? 1.0) : 1.0;
+    const fw = form.cyberService === "compliance" ? (frameworkMult[form.framework] ?? 1.0) : 1.0;
+    const headcountMult = 1 + Math.max(0, form.headcount - 25) / 200; // gentle headcount scaling
+
+    return Math.round((base * scale * urg * dep * fw * headcountMult) / 50) * 50;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitting(true);
-    
+
+    if (isCyber) {
+      const price = computeCyberPrice();
+      const quoteNumber = `CQ-${Date.now().toString(36).toUpperCase()}`;
+      setTimeout(() => {
+        setResult({
+          price,
+          priceRange: { low: Math.round(price * 0.85), high: Math.round(price * 1.15) },
+          quoteNumber,
+        });
+        setStep(3);
+        setSubmitting(false);
+      }, 600);
+      return;
+    }
+
     try {
       const res = await fetch("/api/predict", {
         method: "POST",
@@ -66,8 +113,8 @@ export default function QuoteForm() {
       });
       const data = await res.json();
       const basePrice = data.predicted_price || data.price || 1500;
-      
-      setResult({ 
+
+      setResult({
         price: basePrice,
         priceRange: { low: Math.round(basePrice * 0.85), high: Math.round(basePrice * 1.15) },
         quoteNumber: data.quote_number,
@@ -93,6 +140,13 @@ export default function QuoteForm() {
     { id: "individual", icon: User, title: "Personal / Home", desc: "Residential security, personal protection, or private events" },
     { id: "business", icon: Building2, title: "Business / Office", desc: "Stores, offices, warehouses, or commercial properties" },
     { id: "security", icon: PartyPopper, title: "Event / Venue", desc: "Weddings, conferences, festivals, or special events" },
+    { id: "cyber", icon: Lock, title: "Cybersecurity / Online", desc: "Compliance audits, performance reviews, cloud vs on-prem advisement" },
+  ];
+
+  const cyberServices = [
+    { id: "compliance", title: "Compliance Audit", desc: "SOC 2, HIPAA, PCI-DSS, ISO 27001, NIST gap assessment and remediation roadmap" },
+    { id: "performance", title: "Performance & Hardening Review", desc: "Application, infra, and security posture review with prioritized fixes" },
+    { id: "advisement", title: "Cloud vs On-Prem Advisement", desc: "Architecture, cost, and risk analysis for cloud, on-prem, or hybrid deployments" },
   ];
   
   return (
@@ -146,14 +200,163 @@ export default function QuoteForm() {
           </div>
         )}
 
-        {/* Step 1: Details */}
-        {step === 1 && (
+        {/* Step 1: Details — Cybersecurity branch */}
+        {step === 1 && isCyber && (
+          <div className="animate-fadeIn">
+            <div className="text-center mb-8">
+              <h1 className="text-3xl font-bold mb-2">Tell us about your environment</h1>
+              <p className="text-zinc-400">A few details so we can scope the right engagement</p>
+            </div>
+
+            <form onSubmit={(e) => { e.preventDefault(); setStep(2); }} className="space-y-6">
+              <div>
+                <label className="block text-sm font-medium text-zinc-300 mb-2">What kind of engagement do you need?</label>
+                <div className="space-y-3">
+                  {cyberServices.map((cs) => (
+                    <button
+                      key={cs.id}
+                      type="button"
+                      onClick={() => setForm({ ...form, cyberService: cs.id })}
+                      className={`w-full p-4 rounded-xl text-left transition border ${
+                        form.cyberService === cs.id
+                          ? "border-accent bg-accent/10"
+                          : "border-zinc-800 bg-zinc-900 hover:border-zinc-700"
+                      }`}
+                    >
+                      <div className="font-semibold mb-1">{cs.title}</div>
+                      <div className="text-sm text-zinc-400">{cs.desc}</div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {form.cyberService === "compliance" && (
+                <div>
+                  <label className="block text-sm font-medium text-zinc-300 mb-2">
+                    <Shield className="w-4 h-4 inline mr-1" /> Which framework?
+                  </label>
+                  <select
+                    value={form.framework}
+                    onChange={(e) => setForm({ ...form, framework: e.target.value })}
+                    className="w-full px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-xl text-white focus:border-accent transition"
+                    required
+                  >
+                    <option value="">Select framework...</option>
+                    <option value="SOC2">SOC 2</option>
+                    <option value="HIPAA">HIPAA</option>
+                    <option value="PCI">PCI-DSS</option>
+                    <option value="ISO27001">ISO 27001</option>
+                    <option value="NIST">NIST CSF / 800-53</option>
+                    <option value="other">Other / multiple</option>
+                    <option value="none">Not sure yet</option>
+                  </select>
+                </div>
+              )}
+
+              {(form.cyberService === "advisement" || form.cyberService === "performance") && (
+                <div>
+                  <label className="block text-sm font-medium text-zinc-300 mb-2">
+                    <Cloud className="w-4 h-4 inline mr-1" /> Where does it run today?
+                  </label>
+                  <select
+                    value={form.deployment}
+                    onChange={(e) => setForm({ ...form, deployment: e.target.value })}
+                    className="w-full px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-xl text-white focus:border-accent transition"
+                    required
+                  >
+                    <option value="">Select deployment...</option>
+                    <option value="cloud">Cloud (AWS / Azure / GCP)</option>
+                    <option value="on_prem">On-prem / self-hosted</option>
+                    <option value="hybrid">Hybrid</option>
+                    <option value="unsure">Not sure / evaluating options</option>
+                  </select>
+                </div>
+              )}
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-zinc-300 mb-2">
+                    <Users className="w-4 h-4 inline mr-1" /> Headcount
+                  </label>
+                  <input
+                    type="number"
+                    value={form.headcount}
+                    onChange={(e) => setForm({ ...form, headcount: +e.target.value })}
+                    min={1}
+                    className="w-full px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-xl text-white focus:border-accent transition"
+                    placeholder="25"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-zinc-300 mb-2">Infrastructure scale</label>
+                  <select
+                    value={form.infraScale}
+                    onChange={(e) => setForm({ ...form, infraScale: e.target.value })}
+                    className="w-full px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-xl text-white focus:border-accent transition"
+                    required
+                  >
+                    <option value="">Select scale...</option>
+                    <option value="small">Small (&lt;10 services)</option>
+                    <option value="medium">Medium (10–50 services)</option>
+                    <option value="large">Large (50+ services / multi-region)</option>
+                  </select>
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-zinc-300 mb-2">
+                  <Clock className="w-4 h-4 inline mr-1" /> How soon do you need this?
+                </label>
+                <select
+                  value={form.urgency}
+                  onChange={(e) => setForm({ ...form, urgency: e.target.value })}
+                  className="w-full px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-xl text-white focus:border-accent transition"
+                  required
+                >
+                  <option value="">Select timeline...</option>
+                  <option value="standard">Standard (4–8 weeks)</option>
+                  <option value="priority">Priority (2–4 weeks)</option>
+                  <option value="urgent">Urgent (&lt;2 weeks)</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-zinc-300 mb-2">
+                  Anything else we should know? (optional)
+                </label>
+                <textarea
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  rows={3}
+                  className="w-full px-4 py-3 bg-zinc-900 border border-zinc-700 rounded-xl text-white focus:border-accent transition resize-none"
+                  placeholder="Current pain points, prior audits, regulators involved, etc."
+                />
+              </div>
+
+              <div className="flex gap-4 pt-4">
+                <button type="button" onClick={() => setStep(0)} className="px-6 py-3 border border-zinc-700 hover:bg-zinc-800 rounded-xl transition">
+                  Back
+                </button>
+                <button
+                  type="submit"
+                  disabled={!form.cyberService || !form.infraScale || !form.urgency}
+                  className="flex-1 py-3 bg-accent hover:bg-orange-600 disabled:bg-zinc-700 disabled:cursor-not-allowed text-black font-semibold rounded-xl transition flex items-center justify-center gap-2"
+                >
+                  Continue <ChevronRight className="w-5 h-5" />
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {/* Step 1: Details — Physical branch */}
+        {step === 1 && !isCyber && (
           <div className="animate-fadeIn">
             <div className="text-center mb-8">
               <h1 className="text-3xl font-bold mb-2">Tell us the basics</h1>
               <p className="text-zinc-400">Just a few details to calculate your quote</p>
             </div>
-            
+
             <form onSubmit={(e) => { e.preventDefault(); setStep(2); }} className="space-y-6">
               <div>
                 <label className="block text-sm font-medium text-zinc-300 mb-2">


### PR DESCRIPTION
## Summary
- Adds a fourth `/quote` option (Cybersecurity / Online) alongside Personal, Business, and Event
- Branched Step 1 covering compliance audits, performance reviews, and cloud-vs-on-prem advisement
- Pricing computed client-side from a rules table (service base x infra scale x urgency x deployment x framework x headcount), so the demo path does not depend on backend/ML changes
- Footer link added in `PublicLayout` so `/quote/cyber` is discoverable

## Test plan
- [ ] Visit `/quote`, confirm 4 cards render
- [ ] Pick "Cybersecurity / Online", confirm Step 1 shows engagement-type buttons
- [ ] Compliance branch surfaces framework dropdown; Performance/Advisement branch surfaces deployment dropdown
- [ ] Submit a cyber quote, confirm a `CQ-...` quote number and price range appear
- [ ] Existing physical paths (individual / business / security) still work end to end